### PR TITLE
fix(docker): convert bool env-vars to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /tmp
 /volumes
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       # See the .env.example file in the GitHub repo for all available options while we work on the docs.
       # https://github.com/kin-labs/kinetic/blob/dev/.env.example
       API_URL: "http://localhost:3000/api"
-      AUTH_PASSWORD_ENABLED: true
+      AUTH_PASSWORD_ENABLED: "True"
       # Provision users with a coma-separated list.
       # Each item has the form: <username>|<password?>|<role?>:<email?>:<avatarUrl?>
       # The password is optional, when left blank the user can only log in with an external provider.
@@ -26,13 +26,13 @@ services:
       APP_1_FEE_PAYER_BYTE_ARRAY: "[24,20,238,188,26,234,120,209,88,63,170,46,66,98,21,113,194,120,143,228,231,37,91,0,242,32,180,99,243,179,57,144,11,233,235,235,203,20,105,33,47,140,152,253,12,148,72,175,141,253,242,110,225,110,21,211,118,87,111,206,208,166,190,78]"
       APP_1_NAME: "App 1"
       COOKIE_DOMAINS: "localhost"
-      CORS_BYPASS: true
+      CORS_BYPASS: "True"
       DATABASE_URL: "postgresql://prisma:prisma@postgres:5432/prisma?schema:kinetic"
       JWT_SECRET: "ENTER_YOUR_SECRET"
       LOG_LEVEL: ALL
       # Devnet is enabled by default, you need to explicitly enable mainnet.
-      SOLANA_DEVNET_ENABLED: true
-      SOLANA_MAINNET_ENABLED: false
+      SOLANA_DEVNET_ENABLED: "True"
+      SOLANA_MAINNET_ENABLED: "False"
       WEB_URL: "http://localhost:3000"
     logging:
       options:


### PR DESCRIPTION
compose does not accept unquoted env-vars for bool and won't run